### PR TITLE
Add Helm chart and GCP bootstrap Terraform for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ A comprehensive Governance, Risk, and Compliance (GRC) toolkit that provides AI-
 4. Enter a GRC scenario and click "Analyze Scenario"
 
 ### Containerized Deployment
-For production deployment to GCP Kubernetes, see the [Deployment Guide](docs/DEPLOYMENT.md) and [GCP Deployment Checklist](docs/GCP-DEPLOYMENT-CHECKLIST.md).
+- **Helm (any Kubernetes / CSP)**: [Helm & Terraform guide](docs/HELM-TERRAFORM.md) — chart in `charts/grc-toolkit/`.
+- **GCP**: [Deployment Guide](docs/DEPLOYMENT.md) and [GCP Deployment Checklist](docs/GCP-DEPLOYMENT-CHECKLIST.md).
 
 ```bash
 # Setup and deploy to GCP
@@ -38,6 +39,7 @@ Detailed documentation for the GRCToolKit can be found in the `docs/` directory:
   - [Roadmap](docs/ROADMAP.md) - Project development phases and future enhancements.
 
 - **Deployment & Operations**:
+  - [Helm & Terraform](docs/HELM-TERRAFORM.md) - Helm chart for any Kubernetes; optional GCP Terraform bootstrap.
   - [Deployment Guide](docs/DEPLOYMENT.md) - General deployment instructions.
   - [GCP Deployment Checklist](docs/GCP-DEPLOYMENT-CHECKLIST.md) - Specific steps for Google Cloud Platform.
   - [Secrets Setup](docs/SECRETS-SETUP.md) - API keys and secrets (GitHub Actions, GCP Secret Manager, local).

--- a/charts/grc-toolkit/Chart.yaml
+++ b/charts/grc-toolkit/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: grc-toolkit
+description: GRC Toolkit — portable Kubernetes deployment (any CSP)
+type: application
+version: 0.1.0
+appVersion: "2.1.0-dev"
+keywords:
+  - grc
+  - compliance
+  - nist
+  - oscal
+maintainers:
+  - name: iFocus Innovations

--- a/charts/grc-toolkit/README.md
+++ b/charts/grc-toolkit/README.md
@@ -1,0 +1,41 @@
+# grc-toolkit Helm chart
+
+Portable install for **any Kubernetes** (EKS, AKS, GKE, on-prem). Point `image.registry` / `image.repository` at **your** container registry.
+
+## Quick install
+
+```bash
+# Create namespace secret first (recommended)
+kubectl create namespace grc-toolkit
+kubectl create secret generic grc-toolkit-secrets \
+  --namespace grc-toolkit \
+  --from-literal=gemini-api-key='YOUR_GEMINI_API_KEY'
+
+helm install grc ./charts/grc-toolkit \
+  --namespace grc-toolkit \
+  --set image.registry=REGISTRY_HOST \
+  --set image.repository=PATH_TO_IMAGE \
+  --set image.tag=2.1.0-dev
+```
+
+## GCP Artifact Registry example
+
+```bash
+export REG=us-central1-docker.pkg.dev
+export PROJECT=my-gcp-project
+export REPO=grc-toolkit
+
+helm upgrade --install grc ./charts/grc-toolkit \
+  --namespace grc-toolkit --create-namespace \
+  --set image.registry=${REG}/${PROJECT}/${REPO} \
+  --set image.repository=grc-toolkit \
+  --set image.tag=latest
+```
+
+## Ingress (optional)
+
+Enable and set **cloud-specific** annotations in a values file — see `values-ingress-nginx.yaml` / `values-ingress-gke.yaml` patterns in [docs/HELM-TERRAFORM.md](../../docs/HELM-TERRAFORM.md).
+
+## Values reference
+
+See `values.yaml` for `ingress`, `hpa`, `resources`, `secret.create`, and `gemini.enabled`.

--- a/charts/grc-toolkit/examples/values-ingress-gke.yaml
+++ b/charts/grc-toolkit/examples/values-ingress-gke.yaml
@@ -1,0 +1,16 @@
+# Google GKE Ingress + managed cert (adjust names to your project)
+ingress:
+  enabled: true
+  className: "gce"
+  annotations:
+    kubernetes.io/ingress.class: "gce"
+    kubernetes.io/ingress.global-static-ip-name: "grc-toolkit-ip"
+    networking.gke.io/managed-certificates: "grc-toolkit-ssl-cert"
+  hosts:
+    - host: grc-toolkit.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    enabled: true
+    secretName: grc-toolkit-tls

--- a/charts/grc-toolkit/examples/values-ingress-nginx.yaml
+++ b/charts/grc-toolkit/examples/values-ingress-nginx.yaml
@@ -1,0 +1,14 @@
+# Generic NGINX Ingress Controller (EKS, AKS, on-prem, etc.)
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  hosts:
+    - host: grc-toolkit.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    enabled: true
+    secretName: grc-toolkit-tls

--- a/charts/grc-toolkit/templates/NOTES.txt
+++ b/charts/grc-toolkit/templates/NOTES.txt
@@ -1,0 +1,16 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls.enabled }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else }}
+  kubectl --namespace {{ include "grc-toolkit.namespace" . }} port-forward service/grc-toolkit-service 8080:{{ .Values.service.port }}
+  Then open http://localhost:8080
+{{- end }}
+
+2. Ensure the Gemini API secret exists (unless gemini.enabled is false):
+   kubectl create secret generic {{ .Values.gemini.secretName }} \
+     --namespace {{ include "grc-toolkit.namespace" . }} \
+     --from-literal={{ .Values.gemini.secretKey }}='YOUR_KEY'
+
+Image in use: {{ include "grc-toolkit.image" . }}

--- a/charts/grc-toolkit/templates/_helpers.tpl
+++ b/charts/grc-toolkit/templates/_helpers.tpl
@@ -1,0 +1,73 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "grc-toolkit.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "grc-toolkit.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart label
+*/}}
+{{- define "grc-toolkit.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "grc-toolkit.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "grc-toolkit.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app: grc-toolkit
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "grc-toolkit.labels" -}}
+helm.sh/chart: {{ include "grc-toolkit.chart" . }}
+{{ include "grc-toolkit.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Image reference
+*/}}
+{{- define "grc-toolkit.image" -}}
+{{- if .Values.image.full -}}
+{{- .Values.image.full -}}
+{{- else -}}
+{{- $reg := .Values.image.registry -}}
+{{- $repo := .Values.image.repository -}}
+{{- $tag := .Values.image.tag | toString -}}
+{{- if $reg -}}
+{{- printf "%s/%s:%s" $reg $repo $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Namespace name
+*/}}
+{{- define "grc-toolkit.namespace" -}}
+{{- .Values.namespace.name }}
+{{- end }}

--- a/charts/grc-toolkit/templates/configmap.yaml
+++ b/charts/grc-toolkit/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grc-toolkit-config
+  namespace: {{ include "grc-toolkit.namespace" . }}
+  labels:
+    {{- include "grc-toolkit.labels" . | nindent 4 }}
+data:
+  APP_NAME: {{ .Values.config.appName | quote }}
+  APP_VERSION: {{ .Values.config.appVersion | quote }}
+  APP_BUILD_DATE: {{ .Values.config.appBuildDate | default (now | date "2006-01-02") | quote }}
+  FEATURE_PQC: {{ .Values.config.featurePqc | quote }}

--- a/charts/grc-toolkit/templates/deployment.yaml
+++ b/charts/grc-toolkit/templates/deployment.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grc-toolkit
+  namespace: {{ include "grc-toolkit.namespace" . }}
+  labels:
+    {{- include "grc-toolkit.labels" . | nindent 4 }}
+    app: grc-toolkit
+    version: {{ .Chart.AppVersion | quote }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "grc-toolkit.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "grc-toolkit.selectorLabels" . | nindent 8 }}
+        version: {{ .Chart.AppVersion | quote }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: grc-toolkit
+          image: {{ include "grc-toolkit.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+          env:
+            - name: APP_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: grc-toolkit-config
+                  key: APP_NAME
+            - name: APP_VERSION
+              valueFrom:
+                configMapKeyRef:
+                  name: grc-toolkit-config
+                  key: APP_VERSION
+            {{- if .Values.gemini.enabled }}
+            - name: GEMINI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.gemini.secretName }}
+                  key: {{ .Values.gemini.secretKey }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.service.targetPort }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.service.targetPort }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - echo 'PreStop hook' && sleep 2
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      restartPolicy: Always

--- a/charts/grc-toolkit/templates/hpa.yaml
+++ b/charts/grc-toolkit/templates/hpa.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: grc-toolkit-hpa
+  namespace: {{ include "grc-toolkit.namespace" . }}
+  labels:
+    {{- include "grc-toolkit.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: grc-toolkit
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 10
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Percent
+          value: 50
+          periodSeconds: 60
+{{- end }}

--- a/charts/grc-toolkit/templates/ingress.yaml
+++ b/charts/grc-toolkit/templates/ingress.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grc-toolkit-ingress
+  namespace: {{ include "grc-toolkit.namespace" . }}
+  labels:
+    {{- include "grc-toolkit.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        {{- range .Values.ingress.hosts }}
+        - {{ .host | quote }}
+        {{- end }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: grc-toolkit-service
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/grc-toolkit/templates/namespace.yaml
+++ b/charts/grc-toolkit/templates/namespace.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.namespace.create }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "grc-toolkit.namespace" . }}
+  labels:
+    {{- include "grc-toolkit.labels" . | nindent 4 }}
+    name: {{ include "grc-toolkit.namespace" . }}
+{{- end }}

--- a/charts/grc-toolkit/templates/secret.yaml
+++ b/charts/grc-toolkit/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.secret.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.gemini.secretName }}
+  namespace: {{ include "grc-toolkit.namespace" . }}
+  labels:
+    {{- include "grc-toolkit.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.gemini.secretKey }}: {{ required "secret.geminiApiKey is required when secret.create=true" .Values.secret.geminiApiKey | quote }}
+{{- end }}

--- a/charts/grc-toolkit/templates/service.yaml
+++ b/charts/grc-toolkit/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grc-toolkit-service
+  namespace: {{ include "grc-toolkit.namespace" . }}
+  labels:
+    {{- include "grc-toolkit.labels" . | nindent 4 }}
+    app: grc-toolkit
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "grc-toolkit.selectorLabels" . | nindent 4 }}

--- a/charts/grc-toolkit/values.yaml
+++ b/charts/grc-toolkit/values.yaml
@@ -1,0 +1,92 @@
+# Default values — set image.registry/repository/tag for your environment.
+
+nameOverride: ""
+fullnameOverride: ""
+
+namespace:
+  create: true
+  name: grc-toolkit
+
+image:
+  # Option A: set full reference (overrides registry/repository/tag)
+  full: ""
+  # Option B: registry + repository + tag (e.g. ECR: 123.dkr.ecr.region.amazonaws.com/myapp / grc-toolkit)
+  registry: ""
+  repository: grc-toolkit
+  tag: "2.1.0-dev"
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+replicaCount: 3
+
+podAnnotations: {}
+
+# Match your container image user (official nginx:alpine uses 101)
+podSecurityContext:
+  fsGroup: 101
+
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 101
+  capabilities:
+    drop:
+      - ALL
+
+resources:
+  requests:
+    memory: "64Mi"
+    cpu: "50m"
+  limits:
+    memory: "128Mi"
+    cpu: "100m"
+
+# App metadata (ConfigMap)
+config:
+  appName: "GRC Toolkit"
+  appVersion: "2.1.0-dev"
+  appBuildDate: ""
+  featurePqc: "enabled"
+
+# Gemini API — requires a Kubernetes Secret (see secret.*)
+gemini:
+  enabled: true
+  secretName: grc-toolkit-secrets
+  secretKey: gemini-api-key
+
+# Create Secret from Helm (not recommended for production; prefer External Secrets / kubectl)
+secret:
+  create: false
+  # If create=true, set at install time: --set secret.geminiApiKey=... (exposes in shell history)
+  geminiApiKey: ""
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8080
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  # Example profiles (pick one cloud; set ingress.annotations in your values file):
+  # GKE: kubernetes.io/ingress.class: gce
+  # NGINX: kubernetes.io/ingress.class: nginx
+  # AWS ALB: alb.ingress.kubernetes.io/scheme: internet-facing
+  hosts:
+    - host: grc-toolkit.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    enabled: false
+    secretName: grc-toolkit-tls
+
+hpa:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+terminationGracePeriodSeconds: 30

--- a/docs/HELM-TERRAFORM.md
+++ b/docs/HELM-TERRAFORM.md
@@ -1,0 +1,94 @@
+# Helm & Terraform (portable Kubernetes delivery)
+
+This repo supports **vendor-neutral Kubernetes** installs via **Helm**, with an **optional Terraform** module for **GCP dev bootstrap** (Artifact Registry + APIs). Customers on AWS, Azure, or other clouds use the same chart with their own registry and ingress settings.
+
+## Helm chart
+
+Location: [`charts/grc-toolkit`](../charts/grc-toolkit/).
+
+### Install (any cluster)
+
+1. Build and push your image to **your** registry (ECR, ACR, GAR, Harbor, etc.).
+2. Create the Gemini secret (or disable `gemini.enabled` for static-only demos):
+
+   ```bash
+   kubectl create namespace grc-toolkit
+   kubectl create secret generic grc-toolkit-secrets \
+     --namespace grc-toolkit \
+     --from-literal=gemini-api-key='YOUR_KEY'
+   ```
+
+3. Install:
+
+   ```bash
+   helm upgrade --install grc ./charts/grc-toolkit \
+     --namespace grc-toolkit \
+     --set image.full=YOUR_REGISTRY/PATH/grc-toolkit:TAG
+   ```
+
+   Or use split fields (see `values.yaml`):
+
+   ```bash
+   helm upgrade --install grc ./charts/grc-toolkit \
+     --namespace grc-toolkit \
+     --set image.registry=us-central1-docker.pkg.dev/PROJECT/REPO_NAME \
+     --set image.repository=grc-toolkit \
+     --set image.tag=latest
+   ```
+
+### Ingress examples
+
+- GKE: [`charts/grc-toolkit/examples/values-ingress-gke.yaml`](../charts/grc-toolkit/examples/values-ingress-gke.yaml)
+- NGINX Ingress: [`charts/grc-toolkit/examples/values-ingress-nginx.yaml`](../charts/grc-toolkit/examples/values-ingress-nginx.yaml)
+
+```bash
+helm upgrade --install grc ./charts/grc-toolkit \
+  -f charts/grc-toolkit/examples/values-ingress-nginx.yaml \
+  --set image.full=...
+```
+
+### Relationship to `k8s/` manifests
+
+The `k8s/` directory remains a **flat reference** for tutorials and scripts. **Helm is the recommended install path** for repeatable, configurable deployments.
+
+---
+
+## Terraform (GCP bootstrap only)
+
+Location: [`terraform/gcp-bootstrap`](../terraform/gcp-bootstrap/).
+
+Creates:
+
+- **Artifact Registry** Docker repository
+- Enables **APIs**: Artifact Registry, optional GKE/Secret Manager related services
+
+It does **not** create a GKE cluster (keeps cost and lock-in optional). Add your own Terraform for EKS/AKS/GKE when needed.
+
+### Usage
+
+**Do not commit `project_id`.** Use `TF_VAR_project_id` from CI secrets, a gitignored `terraform.tfvars`, or Secret Manager — see [`terraform/gcp-bootstrap/README.md`](../terraform/gcp-bootstrap/README.md).
+
+```bash
+cd terraform/gcp-bootstrap
+export TF_VAR_project_id="..."   # from your secret store in real deployments
+terraform init
+terraform plan
+terraform apply
+```
+
+Use the output `helm_image_registry_hint` with Helm `image.registry` + your image name.
+
+---
+
+## Selling / multi-cloud positioning
+
+- **Ship**: OCI image + Helm chart + install docs.
+- **Customer**: Supplies registry, cluster, ingress class, and secrets (or External Secrets).
+- **Your dev**: Terraform `gcp-bootstrap` + GKE (your choice) + Helm with GAR image.
+
+---
+
+## References
+
+- [Secrets setup](SECRETS-SETUP.md)
+- [GCP deployment checklist](GCP-DEPLOYMENT-CHECKLIST.md)

--- a/terraform/gcp-bootstrap/.gitignore
+++ b/terraform/gcp-bootstrap/.gitignore
@@ -1,0 +1,6 @@
+.terraform/
+*.tfstate
+*.tfstate.*
+.terraform.lock.hcl
+terraform.tfvars
+crash.log

--- a/terraform/gcp-bootstrap/README.md
+++ b/terraform/gcp-bootstrap/README.md
@@ -1,0 +1,64 @@
+# GCP bootstrap (Terraform)
+
+Creates Artifact Registry and enables APIs. **Do not commit `project_id`** — pass it from your secret store or from Secret Manager.
+
+## Variables
+
+| Input | Sensitive | How to set |
+|-------|-----------|------------|
+| `project_id` | yes | `TF_VAR_project_id`, gitignored `terraform.tfvars`, or `load-vars-from-secret.sh` |
+| `region` | no | default `us-central1` |
+| `repository_id` | no | default `grc-toolkit` |
+
+## Option A — CI / deployment secrets (GitHub Actions, etc.)
+
+Store `GCP_PROJECT_ID` (or equivalent) in your platform’s secret store, then:
+
+```yaml
+env:
+  TF_VAR_project_id: ${{ secrets.GCP_PROJECT_ID }}
+```
+
+```bash
+terraform plan
+terraform apply
+```
+
+## Option B — Google Secret Manager
+
+1. Create a secret (same project you bootstrap, or a dedicated “org config” project):
+
+   ```bash
+   echo '{"project_id":"YOUR_PROJECT_ID","region":"us-central1","repository_id":"grc-toolkit"}' | \
+     gcloud secrets create grc-toolkit-terraform-bootstrap --data-file=- --project=YOUR_PROJECT_ID
+   ```
+
+2. Before `terraform plan` / `apply`:
+
+   ```bash
+   cd terraform/gcp-bootstrap
+   source ./load-vars-from-secret.sh
+   terraform init
+   terraform apply
+   ```
+
+   Override secret name or project:
+
+   ```bash
+   export GCP_BOOTSTRAP_SECRET_NAME=my-bootstrap-config
+   export GCP_BOOTSTRAP_LOOKUP_PROJECT=my-org-config-project
+   source ./load-vars-from-secret.sh
+   ```
+
+## Option C — Local only
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars (file is gitignored)
+terraform apply
+```
+
+## Files
+
+- `terraform.tfvars.example` — documentation only (no real IDs).
+- `load-vars-from-secret.sh` — exports `TF_VAR_*` from GSM JSON.

--- a/terraform/gcp-bootstrap/load-vars-from-secret.sh
+++ b/terraform/gcp-bootstrap/load-vars-from-secret.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Load Terraform variables from a Google Secret Manager JSON payload.
+# Use during deployment so project_id is not stored in git.
+#
+# Prereqs: gcloud auth (user or SA), Secret Manager API enabled on the project
+# that HOLDS the secret (often the same GCP project you are bootstrapping).
+#
+# Secret payload format (plain JSON string in GSM):
+#   {"project_id":"my-gcp-project","region":"us-central1","repository_id":"grc-toolkit"}
+#
+# Usage:
+#   source ./load-vars-from-secret.sh
+#   terraform plan
+#
+# Env overrides:
+#   GCP_BOOTSTRAP_SECRET_NAME   (default: grc-toolkit-terraform-bootstrap)
+#   GCP_BOOTSTRAP_LOOKUP_PROJECT (project id where the secret lives; else gcloud config)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SECRET_NAME="${GCP_BOOTSTRAP_SECRET_NAME:-grc-toolkit-terraform-bootstrap}"
+LOOKUP_PROJECT="${GCP_BOOTSTRAP_LOOKUP_PROJECT:-}"
+
+if [[ -z "${LOOKUP_PROJECT}" ]]; then
+  LOOKUP_PROJECT="$(gcloud config get-value project 2>/dev/null || true)"
+fi
+
+if [[ -z "${LOOKUP_PROJECT}" ]]; then
+  echo "load-vars-from-secret.sh: set GCP_BOOTSTRAP_LOOKUP_PROJECT or run: gcloud config set project YOUR_PROJECT" >&2
+  exit 1
+fi
+
+JSON="$(gcloud secrets versions access latest --secret="${SECRET_NAME}" --project="${LOOKUP_PROJECT}")"
+
+if command -v jq >/dev/null 2>&1; then
+  export TF_VAR_project_id="$(echo "${JSON}" | jq -r '.project_id')"
+  _region="$(echo "${JSON}" | jq -r '.region // empty')"
+  _repo="$(echo "${JSON}" | jq -r '.repository_id // empty')"
+  if [[ -n "${_region}" && "${_region}" != "null" ]]; then
+    export TF_VAR_region="${_region}"
+  fi
+  if [[ -n "${_repo}" && "${_repo}" != "null" ]]; then
+    export TF_VAR_repository_id="${_repo}"
+  fi
+else
+  echo "load-vars-from-secret.sh: jq is required to parse the secret JSON" >&2
+  exit 1
+fi
+
+if [[ -z "${TF_VAR_project_id}" || "${TF_VAR_project_id}" == "null" ]]; then
+  echo "load-vars-from-secret.sh: secret missing .project_id" >&2
+  exit 1
+fi
+
+echo "Loaded TF_VAR_project_id from Secret Manager secret '${SECRET_NAME}' (project ${LOOKUP_PROJECT})." >&2

--- a/terraform/gcp-bootstrap/main.tf
+++ b/terraform/gcp-bootstrap/main.tf
@@ -1,0 +1,30 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+locals {
+  apis = var.enable_apis ? toset([
+    "artifactregistry.googleapis.com",
+    "containerregistry.googleapis.com",
+    "container.googleapis.com",
+    "secretmanager.googleapis.com",
+  ]) : toset([])
+}
+
+resource "google_project_service" "enabled" {
+  for_each = local.apis
+
+  project            = var.project_id
+  service            = each.key
+  disable_on_destroy = false
+}
+
+resource "google_artifact_registry_repository" "grc_toolkit" {
+  location      = var.region
+  repository_id = var.repository_id
+  description   = "GRC Toolkit container images (dev / distribution)"
+  format        = "DOCKER"
+
+  depends_on = [google_project_service.enabled]
+}

--- a/terraform/gcp-bootstrap/outputs.tf
+++ b/terraform/gcp-bootstrap/outputs.tf
@@ -1,0 +1,14 @@
+output "artifact_registry_location" {
+  description = "Region of the Docker repository"
+  value       = google_artifact_registry_repository.grc_toolkit.location
+}
+
+output "artifact_registry_repository" {
+  description = "Full path prefix for docker push (without image name)"
+  value       = "${var.region}-docker.pkg.dev/${var.project_id}/${var.repository_id}"
+}
+
+output "helm_image_registry_hint" {
+  description = "Use as Helm --set image.registry when repository name matches image"
+  value       = "${var.region}-docker.pkg.dev/${var.project_id}/${var.repository_id}"
+}

--- a/terraform/gcp-bootstrap/terraform.tfvars.example
+++ b/terraform/gcp-bootstrap/terraform.tfvars.example
@@ -1,0 +1,19 @@
+# Do not commit real values. Use one of the following:
+#
+# 1) Environment variables (recommended for CI — inject from your secret store):
+#    export TF_VAR_project_id="<from-secrets>"
+#    export TF_VAR_region="us-central1"   # optional; has default
+#    terraform plan
+#
+# 2) Local file (gitignored): copy to terraform.tfvars and never commit:
+#    cp terraform.tfvars.example terraform.tfvars
+#    # Edit terraform.tfvars locally only; add terraform.tfvars to .gitignore (already listed)
+#
+# 3) Google Secret Manager — load before terraform (see load-vars-from-secret.sh):
+#    source ./load-vars-from-secret.sh
+#    terraform plan
+#
+# Example local-only terraform.tfvars (DO NOT COMMIT):
+#   project_id    = "my-real-project"
+#   region        = "us-central1"
+#   repository_id = "grc-toolkit"

--- a/terraform/gcp-bootstrap/variables.tf
+++ b/terraform/gcp-bootstrap/variables.tf
@@ -1,0 +1,23 @@
+variable "project_id" {
+  description = "GCP project ID — supply via TF_VAR_project_id, terraform.tfvars (gitignored), or load-vars-from-secret.sh"
+  type        = string
+  sensitive   = true
+}
+
+variable "region" {
+  description = "GCP region for Artifact Registry"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "repository_id" {
+  description = "Artifact Registry Docker repository id"
+  type        = string
+  default     = "grc-toolkit"
+}
+
+variable "enable_apis" {
+  description = "Enable commonly used APIs for container + optional GKE"
+  type        = bool
+  default     = true
+}

--- a/terraform/gcp-bootstrap/versions.tf
+++ b/terraform/gcp-bootstrap/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}


### PR DESCRIPTION
- Ship grc-toolkit Helm chart (deployment, service, ingress, HPA, config/secret patterns).

- Add terraform/gcp-bootstrap for GKE-oriented bootstrap with Secret Manager–friendly vars.

- Document Helm + Terraform flow in docs/HELM-TERRAFORM.md and update README.

Made-with: Cursor