### PR TITLE
Docs: GCP lower-env path for sys admins; Actions on Node 24

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -20,7 +20,7 @@ jobs:
       DOCKER_SCOUT_TOKEN: ${{ secrets.DOCKER_SCOUT_TOKEN }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Enforce pinned image versions
       run: |
@@ -33,10 +33,10 @@ jobs:
         scripts/check-container-hardening.sh
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Build Docker image for testing
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         context: .
         push: false
@@ -65,7 +65,7 @@ jobs:
 
     - name: Docker Scout image scan
       if: ${{ env.DOCKER_SCOUT_TOKEN != '' }}
-      uses: docker/scout-action@v1
+      uses: docker/scout-action@v1.20.3
       with:
         command: cves
         image: grc-toolkit:test
@@ -118,26 +118,26 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Google Auth
       id: auth
-      uses: 'google-github-actions/auth@v2'
+      uses: 'google-github-actions/auth@v3'
       with:
         credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
     - name: Set up Cloud SDK
-      uses: 'google-github-actions/setup-gcloud@v2'
+      uses: 'google-github-actions/setup-gcloud@v3'
 
     - name: Configure Docker to use gcloud as a credential helper
       run: gcloud auth configure-docker $GAR_LOCATION-docker.pkg.dev
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Extract metadata
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: $GAR_LOCATION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/$SERVICE
         tags: |
@@ -147,7 +147,7 @@ jobs:
           type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         context: .
         push: true
@@ -165,16 +165,16 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Google Auth
       id: auth
-      uses: 'google-github-actions/auth@v2'
+      uses: 'google-github-actions/auth@v3'
       with:
         credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
     - name: Set up Cloud SDK
-      uses: 'google-github-actions/setup-gcloud@v2'
+      uses: 'google-github-actions/setup-gcloud@v3'
 
     - name: Configure kubectl
       run: gcloud container clusters get-credentials ${{ secrets.GKE_CLUSTER_NAME }} --region $REGION --project $PROJECT_ID
@@ -214,16 +214,16 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Google Auth
       id: auth
-      uses: 'google-github-actions/auth@v2'
+      uses: 'google-github-actions/auth@v3'
       with:
         credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
     - name: Set up Cloud SDK
-      uses: 'google-github-actions/setup-gcloud@v2'
+      uses: 'google-github-actions/setup-gcloud@v3'
 
     - name: Configure kubectl
       run: gcloud container clusters get-credentials ${{ secrets.GKE_CLUSTER_NAME }} --region $REGION --project $PROJECT_ID

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -13,7 +13,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Enforce pinned image versions
       run: |
@@ -26,10 +26,10 @@ jobs:
         scripts/check-container-hardening.sh
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Build Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         context: .
         push: false
@@ -64,7 +64,7 @@ jobs:
 
     - name: Docker Scout image scan
       if: ${{ env.DOCKER_SCOUT_TOKEN != '' }}
-      uses: docker/scout-action@v1
+      uses: docker/scout-action@v1.20.3
       with:
         command: cves
         image: grc-toolkit:pr-test

--- a/README.md
+++ b/README.md
@@ -19,14 +19,23 @@ A comprehensive Governance, Risk, and Compliance (GRC) toolkit that provides AI-
 4. Enter a GRC scenario and click "Analyze Scenario"
 
 ### Containerized Deployment
-- **Helm (any Kubernetes / CSP)**: [Helm & Terraform guide](docs/HELM-TERRAFORM.md) — chart in `charts/grc-toolkit/`.
-- **GCP**: [Deployment Guide](docs/DEPLOYMENT.md) and [GCP Deployment Checklist](docs/GCP-DEPLOYMENT-CHECKLIST.md).
+- **Helm (recommended)**: [Helm & Terraform guide](docs/HELM-TERRAFORM.md) — chart in `charts/grc-toolkit/`.
+- **GCP reference**: [Deployment Guide](docs/DEPLOYMENT.md), [GCP Deployment Checklist](docs/GCP-DEPLOYMENT-CHECKLIST.md) (GKE + secrets; use Terraform + Helm below for registry/bootstrap).
+- **Legacy scripts** (flat `k8s/` manifests): `./scripts/setup-gcp.sh` then `./scripts/deploy.sh production`.
 
-```bash
-# Setup and deploy to GCP
-./scripts/setup-gcp.sh
-./scripts/deploy.sh production
-```
+### GCP lower environment (sys admin)
+
+Use this order so you do not duplicate Artifact Registry setup (Terraform already creates the Docker repo and enables core APIs).
+
+1. **Org / project** — Create or choose a **non-production** GCP project, attach **billing**, and set a default region (e.g. `us-central1`). Resolve any **org policies** that block GKE, Artifact Registry, or Secret Manager.
+2. **Terraform identity** — Decide who runs Terraform (your user or a dedicated SA). Grant at least **Service Usage Admin** and **Artifact Registry Admin** on that project (or broader **Editor** / **Owner** for a small dev tenant). Details: [`terraform/gcp-bootstrap/README.md`](terraform/gcp-bootstrap/README.md).
+3. **Bootstrap with Terraform** — From [`terraform/gcp-bootstrap`](terraform/gcp-bootstrap): `terraform init` / `plan` / `apply` using `TF_VAR_project_id` or Secret Manager as documented there. Note the output **`artifact_registry_repository`** / **`helm_image_registry_hint`** (default repo id is `grc-toolkit`, not `grc-toolkit-repo`).
+4. **GKE** — Terraform does **not** create a cluster. Create a **dev GKE** cluster (Console or `gcloud`; see [GCP Deployment Checklist](docs/GCP-DEPLOYMENT-CHECKLIST.md) “GKE Cluster Creation”), then `gcloud container clusters get-credentials …`.
+5. **Registry auth** — `gcloud auth configure-docker REGION-docker.pkg.dev`, then build and push the image to the path from step 3 (same flow as [Helm & Terraform](docs/HELM-TERRAFORM.md)).
+6. **App secrets** — Store **Gemini** (and any other keys) in **Secret Manager** or create a Kubernetes secret; follow [Secrets Setup](docs/SECRETS-SETUP.md). Do not commit keys.
+7. **Install** — `helm upgrade --install` per [Helm & Terraform](docs/HELM-TERRAFORM.md) (use `examples/values-ingress-gke.yaml` or your ingress class).
+
+CI/CD to this project uses GitHub secrets (e.g. `GCP_PROJECT_ID`, service account key or WIF) as described in [Secrets Setup](docs/SECRETS-SETUP.md).
 
 ## 📚 Documentation
 

--- a/docs/GCP-DEPLOYMENT-CHECKLIST.md
+++ b/docs/GCP-DEPLOYMENT-CHECKLIST.md
@@ -4,6 +4,8 @@
 ## Target Environment: GCP Development/QA
 ## Date: 2025-01-XX
 
+**Preferred path for new lower environments:** use Terraform bootstrap ([`terraform/gcp-bootstrap/README.md`](../terraform/gcp-bootstrap/README.md)) for Artifact Registry + API enablement, then Helm ([`docs/HELM-TERRAFORM.md`](HELM-TERRAFORM.md)) to deploy. Skip the manual “Artifact Registry Setup” section below if Terraform already created the repo (default id `grc-toolkit`). This checklist remains useful for **GKE creation**, **kubectl** steps, and operational verification.
+
 ---
 
 ## Pre-Deployment Requirements

--- a/terraform/gcp-bootstrap/README.md
+++ b/terraform/gcp-bootstrap/README.md
@@ -2,6 +2,16 @@
 
 Creates Artifact Registry and enables APIs. **Do not commit `project_id`** — pass it from your secret store or from Secret Manager.
 
+## Prerequisites (sys admin)
+
+- **Project**: A GCP project ID and **billing** enabled.
+- **Who runs Terraform**: Your user (`gcloud auth application-default login`) or a **service account** whose key JSON is used via `GOOGLE_APPLICATION_CREDENTIALS`.
+- **IAM (least privilege for this module)** on that project:
+  - `roles/serviceusage.serviceUsageAdmin` — enable APIs
+  - `roles/artifactregistry.admin` — create the Docker repository  
+  Broader roles such as **Editor** or **Owner** also work for small dev tenants.
+- **Not created here**: GKE clusters, VPC/firewalls, or workload identities. After `apply`, create a dev cluster (Console or `gcloud`) and install with Helm per [`docs/HELM-TERRAFORM.md`](../../docs/HELM-TERRAFORM.md).
+
 ## Variables
 
 | Input | Sensitive | How to set |


### PR DESCRIPTION
- README: Helm-first deploy notes, GCP setup order (Terraform → GKE → Helm), legacy scripts labeled.

- terraform/gcp-bootstrap README: IAM prerequisites and GKE-out-of-scope note.

- GCP deployment checklist: preferred Terraform + Helm path; avoid duplicate GAR.

- Workflows: bump checkout, Docker, Google actions, scout pin for Node 24 deprecation.

Made-with: Cursor